### PR TITLE
add explicit dbPath to data volume dir

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -4,7 +4,11 @@ nodaemon=true
 childlogdir=/var/log/supervisord
 
 [program:dynamodb]
-command=/usr/bin/java -Djava.library.path=/usr/lib/DynamoDBLocal_lib -jar /usr/lib/DynamoDBLocal.jar -port 8002 -sharedDb
+command=/usr/bin/java -Djava.library.path=/usr/lib/DynamoDBLocal_lib
+  -jar /usr/lib/DynamoDBLocal.jar
+  -port 8002
+  -sharedDb
+  -dbPath /var/lib/dynamodb
 
 [program:dynamo-admin]
 command=/usr/local/bin/dynamodb-admin


### PR DESCRIPTION
From the docs:

> -dbPath value — The directory where DynamoDB will write its database file. If you do not specify this option, the file will be written to the current directory.

by specifying our dbPath within a dedicated directory, downstream consumers (e.g. users with a compose override file) can specify a named host data volume and be a bit more aggressive in cleaning up stopped containers without worrying about losing dynamo data. For example:

```
dynamo:
  volumes:
    - dynamo-data:/var/lib/dynamodb

volumes:
  dynamo-data: {}
```
