### PR TITLE
Support arm64 for M1 Mac (Apple Silicon)

### DIFF
--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -1,0 +1,42 @@
+name: Build and push docker image to dockerhub
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+env:
+  DOCKERHUB_REPO: evalphobia/dynamo-local-admin-docker
+
+jobs:
+  main:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set version
+      id: set_version
+      shell: bash
+      run: echo ""::set-output name=VERSION::${{ github.ref_name }}"
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: |
+          ${DOCKERHUB_REPO}:latest
+          ${DOCKERHUB_REPO}:${{ steps.set_version.outputs.VERSION }}

--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Set version
       id: set_version
       shell: bash
-      run: echo ""::set-output name=VERSION::${{ github.ref_name }}"
+      run: echo "::set-output name=VERSION::${{ github.ref_name }}"
     - name: Checkout
       uses: actions/checkout@v2
     - name: Set up QEMU

--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v1
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -38,5 +38,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ${DOCKERHUB_REPO}:latest
-          ${DOCKERHUB_REPO}:${{ steps.set_version.outputs.VERSION }}
+          ${{ env.DOCKERHUB_REPO }}:latest
+          ${{ env.DOCKERHUB_REPO }}:${{ steps.set_version.outputs.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,30 +18,46 @@ MAINTAINER Zach Wily <zach@instructure.com>
 ## Copyright (c) 2015 Node.js contributors
 ##
 
-# gpg keys listed at https://github.com/nodejs/node
-RUN set -ex \
+ENV NODE_VERSION 17.4.0
+
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
+    i386) ARCH='x86';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  # gpg keys listed at https://github.com/nodejs/node#release-keys
+  && set -ex \
   && for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    4ED778F539E3634C779C87C6D7062848A1AB005C \
     94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    74F12602B6F1C4E913FAA37AD3A89613643B6201 \
     71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+    108F52B48DB57BB0CC439B2997B01419BD92F80A \
+    B9E2F5981AA6E0CD28160D9FF13993A75599653C \
   ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-  done
-
-ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.4.0
-
-RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
-  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
   && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
-  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  # smoke tests
+  && node --version \
+  && npm --version
 
 ################################################################################
 ## END COPY
@@ -61,6 +77,7 @@ RUN apt-get update && \
 
 COPY nginx-proxy.conf /etc/nginx-proxy.conf
 COPY supervisord.conf /etc/supervisord.conf
+RUN ln -s /usr/local/openjdk-8/bin/java /usr/bin/java
 RUN mkdir -p /var/log/supervisord
 
 # Configuration for dynamo-admin to know where to hit dynamo.

--- a/nginx-proxy.conf
+++ b/nginx-proxy.conf
@@ -34,7 +34,6 @@ http {
       proxy_redirect off;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
-      proxy_redirect off;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header X-NginX-Proxy true;
       proxy_connect_timeout 60;


### PR DESCRIPTION
This PR support to add arm64 arch.

`openjdk:8-jre` already has arm64 image.
- https://hub.docker.com/layers/openjdk/library/openjdk/8-jre/images/sha256-78be3117c3fbd863ccc879e7de929d61e1713fb936a2e2ea8af23caf4753cb3a?context=explore

So I copied latest node js installation recipe from official docker image.
- https://github.com/nodejs/docker-node/blob/main/17/bullseye/Dockerfile